### PR TITLE
Return an Enumerator for #each_key without a block

### DIFF
--- a/lib/gdbm.rb
+++ b/lib/gdbm.rb
@@ -149,11 +149,17 @@ module GDBM_FFI
 
   #Iterates over each key in the _file_.
   def self.each_key(file)
+    keys = []
     current = self.gdbm_firstkey file
     until current.value.nil?
-      yield current.value
+      if block_given?
+        yield current.value
+      else
+        keys << current.value
+      end
       current = self.gdbm_nextkey file, current
     end
+    block_given? ? nil : keys.each
   end
 
   #Iterates over each value in the _file_.
@@ -345,8 +351,8 @@ class GDBM
   alias :reject! :delete_if
 
   def each_key(&block)
-    GDBM_FFI.each_key file, &block
-    self
+    enumerator = GDBM_FFI.each_key(file, &block)
+    enumerator || self
   end
 
   def each_pair(&block)

--- a/test/test_gdbm-1.8.7.rb
+++ b/test/test_gdbm-1.8.7.rb
@@ -387,6 +387,10 @@ if defined? GDBM
       assert_equal(@gdbm, ret)
     end
 
+    def test_each_key_without_block
+      assert_kind_of Enumerable::Enumerator, @gdbm.each_key
+    end
+
     def test_keys
       assert_equal([], @gdbm.keys)
 

--- a/test/test_gdbm-1.9.1.rb
+++ b/test/test_gdbm-1.9.1.rb
@@ -400,6 +400,10 @@ if defined? GDBM
       assert_equal(@gdbm, ret)
     end
 
+    def test_each_key_without_block
+      assert_kind_of ::Enumerator, @gdbm.each_key
+    end
+
     def test_keys
       assert_equal([], @gdbm.keys)
 


### PR DESCRIPTION
- Makes the implementation more conformant with MRI,
- I've made a Pull Request to MRI Ruby (ruby/ruby#783) adding a test for the same case,
- With Ruby >= 2 it would be etter to return a lazy enumerator.
