### PR TITLE
Rename to ffi-gdbm

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can download and use `gdbm.rb` anyhow you would like.
 
 You can also install it using Ruby Gems:
 
-`gem install gdbm`
+`gem install ffi-gdbm`
 
 or, if using JRuby:
 
@@ -30,7 +30,7 @@ JRuby does not require further installation, but Rubinius will need the FFI gem:
 
 Tests passing on 64 bit Linux with
 
-* JRuby 1.7.21 and 9.0.5.0
+* JRuby 1.7.21 and 9.1.7.0
 
 ### Older Tests
 
@@ -38,15 +38,13 @@ Passing all tests with JRuby 1.4, 1.5.3, 1.6 on 32-bit Linux.
 
 Passing all tests with MRI Ruby 1.8.7, 1.9.1, 1.9.2 with Ruby-FFI 0.5.4, 0.6.3, 1.0.7 on 32-bit Linux.
 
-Something weird happens with temp files (used in tests) with JRuby on Ubuntu. For some reason, it gets permission denied when trying to delete them. Any thoughts on that would be helpful.
-
 Further testing on other systems is welcome!
 
 ## Testing
 
 Two sets of tests are included, copied straight from the MRI distribution. However, they do require the use of ObjectSpace, so this is how to run them with JRuby:
 
-`jruby --1.8 -X+O -r lib/gdbm test/test_gdbm-1.8.7.rb` (Note: only works with JRuby prior to 9.0.0.0)
+`jruby --1.8 -X+O -r lib/gdbm test/test_gdbm-1.8.7.rb` (Note: these tests only work with JRuby prior to 9.0.0.0)
 
 `jruby -X+O -r ./lib/gdbm test/test_gdbm-1.9.1.rb`
 

--- a/gdbm.gemspec
+++ b/gdbm.gemspec
@@ -1,5 +1,5 @@
 Gem::Specification.new do |s|
-	s.name = %q{gdbm}
+	s.name = %q{ffi-gdbm}
 	s.version = "1.3.1"
 	s.authors = ["Justin Collins"]
 	s.summary = %q{Provides access to gdbm through Ruby-FFI, particularly for JRuby and other alternative Ruby implementations.}


### PR DESCRIPTION
Because the [official stdlib](https://github.com/ruby/gdbm) is taking over the `gdbm` gem.